### PR TITLE
Fix 405 response from suggest requests

### DIFF
--- a/annif_client.py
+++ b/annif_client.py
@@ -4,7 +4,7 @@
 import requests
 
 # Default API base URL
-API_BASE = 'http://api.annif.org/v1/'
+API_BASE = 'https://api.annif.org/v1/'
 
 
 class AnnifClient:

--- a/tests/test_annif_client.py
+++ b/tests/test_annif_client.py
@@ -27,7 +27,7 @@ def test_create_client_api_base():
 def test_projects(client):
     datafile = os.path.join(os.path.dirname(__file__), 'data/projects.json')
     responses.add(responses.GET,
-                  'http://api.annif.org/v1/projects',
+                  'https://api.annif.org/v1/projects',
                   body=open(datafile).read())
     result = client.projects
     assert len(result) == 2


### PR DESCRIPTION
@UnniKohonen noted that annif-client was giving 405 error. The default usage

    $ python3 annif_client.py

was crashing in the suggest step:
```
* Analyzing a short text from a string
Traceback (most recent call last):
  File "annif_client.py", line 94, in <module>
    results = annif.suggest(project_id='yso-en',
  File "annif_client.py", line 50, in suggest
    req.raise_for_status()
  File "/home/juhoi/git/Annif-client/venv/lib/python3.8/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 405 Client Error: METHOD NOT ALLOWED for url: https://api.annif.org/v1/projects/yso-en/suggest
```

The default API address has been `http://api.annif.org`, but nowdays some component in the platform of the API is redirecting http traffic to https. The redirection works for GET requests (list projects and show project information), but not for POST requests (suggest).

Fix for this is to use https address: `https://api.annif.org`