### PR TITLE
Remove learn method demo

### DIFF
--- a/annif_client.py
+++ b/annif_client.py
@@ -106,16 +106,3 @@ if __name__ == '__main__':
         for result in results:
             print("<{}>\t{:.4f}\t{}".format(
                 result['uri'], result['score'], result['label']))
-
-    print()
-
-    print("* Learning on a document")
-    documents = [
-        {"subjects":
-            [{"uri": "http://example.org/fox", "label": "fox"}],
-        "text":
-            "the quick brown fox"
-        }
-    ]
-    req = annif.learn(project_id='dummy-en', documents=documents)
-    print(req)

--- a/annif_client.py
+++ b/annif_client.py
@@ -4,7 +4,7 @@
 import requests
 
 # Default API base URL
-API_BASE = 'http://api.annif.org/v1/'
+API_BASE = 'https://api.annif.org/v1/'
 
 
 class AnnifClient:

--- a/tests/test_annif_client.py
+++ b/tests/test_annif_client.py
@@ -27,7 +27,7 @@ def test_create_client_api_base():
 def test_projects(client):
     datafile = os.path.join(os.path.dirname(__file__), 'data/projects.json')
     responses.add(responses.GET,
-                  'http://api.annif.org/v1/projects',
+                  'https://api.annif.org/v1/projects',
                   body=open(datafile).read())
     result = client.projects
     assert len(result) == 2


### PR DESCRIPTION
The default demo usage

$ python3 annif_client.py

was crashing also in the learn step:
```
* Learning on a document
Traceback (most recent call last):
  File "annif_client.py", line 120, in <module>
    req = annif.learn(project_id='dummy-en', documents=documents)
  File "annif_client.py", line 60, in learn
    req.raise_for_status()
  File "/home/juhoi/git/Annif-client/venv/lib/python3.8/site-packages/requests/models.py", line 1021, in raise_for_status
    raise HTTPError(http_error_msg, response=self)
requests.exceptions.HTTPError: 403 Client Error: Forbidden for url: https://api.annif.org/v1/projects/dummy-en/learn
```

This is because the learn endpoint is denied by NGINX. Better to remove demoing of that method.